### PR TITLE
Trim whitespace from guile-config output

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn config_args(cmd: &str) -> Vec<String> {
         .stdout;
     str::from_utf8(&out)
         .expect(&format!("Could not decode `guile-config {}` output as utf-8", cmd))
+        .trim()
         .split(" ")
         .map(|s| s.to_string())
         .collect()


### PR DESCRIPTION
Previously, the last argument from guile-config would include the
trailing newline. This gets passed to clang with the newline and doesn't
work as expected.

On my computer, `guile-config compile` returns:

    -pthread -I/usr/include/guile/2.2

which causes the string "-I/usr/include/guile/2.2\n" to get passed to
libclang, which prevents bindgen from finding the guile header files.

I fixed this by adding .trim() to remove the whitespace from the
beginning and end of the guile-config output.